### PR TITLE
Fix angular 1.6.0 breaks

### DIFF
--- a/public/controllers/themes.js
+++ b/public/controllers/themes.js
@@ -11,9 +11,9 @@
           method: 'GET',
           url: 'https://bootswatch.com/api/3.json',
           skipAuthorization: true
-        }).success(function (data, status, headers, config) {
-          $scope.themes = data.themes;
-        }).error(function (data, status, headers, config) {
+        }).then(function (response) {
+          $scope.themes = response.data.themes;
+        }).catch(function (response) {
         });
       };
 
@@ -23,22 +23,22 @@
         // $scope.selectedTheme = theme
         $('.progress-striped').show();
 
-        $http.get('/api/admin/themes?theme=' + theme.css).success(function (data, status, headers, config) {
-          if (data) {
+        $http.get('/api/admin/themes?theme=' + theme.css).then(function (response) {
+          if (response.data) {
             window.location.reload();
           }
-        }).error(function (data, status, headers, config) {
+        }).catch(function (response) {
           alert('error');
           $('.progress-striped').hide();
         });
       };
 
       $scope.defaultTheme = function () {
-        $http.get('/api/admin/themes/defaultTheme').success(function (data, status, headers, config) {
-          if (data) {
+        $http.get('/api/admin/themes/defaultTheme').then(function (response) {
+          if (response.data) {
             window.location.reload();
           }
-        }).error(function (data, status, headers, config) {
+        }).catch(function (response) {
           alert('error');
         });
       };

--- a/public/services/module-settings.js
+++ b/public/services/module-settings.js
@@ -1,43 +1,40 @@
-(function() {
-  'use strict';
-
-  angular.module('mean.admin').factory('ModuleSettings', ['$http', '$q',
-    function ($http, $q) {
-      return {
-        get: function (name) {
-          var deferred = $q.defer();
-          $http.get('/api/admin/moduleSettings/' + name)
-            .success(function (data) {
-              deferred.resolve(data);
-            })
-            .error(function (data) {
-              deferred.reject(data);
-            });
-          return deferred.promise;
-        },
-        update: function (name, data) {
-          var deferred = $q.defer();
-          $http.put('/api/admin/moduleSettings/' + name, data)
-            .success(function (data) {
-              deferred.resolve(data);
-            })
-            .error(function (data) {
-              deferred.reject(data);
-            });
-          return deferred.promise;
-        },
-        save: function (name, data) {
-          var deferred = $q.defer();
-          $http.post('/api/admin/moduleSettings/' + name, data)
-            .success(function (data) {
-              deferred.resolve(data);
-            })
-            .error(function (data) {
-              deferred.reject(data);
-            });
-          return deferred.promise;
-        }
-      };
-    }
-  ]);
-})();
+'use strict';
+angular.module('mean.admin').factory('ModuleSettings', ['$http', '$q',
+	function($http, $q) {
+		return {
+			get: function(name) {
+				var deferred = $q.defer();
+				$http.get('/api/admin/moduleSettings/' + name)
+					.then(function(response) {
+						deferred.resolve(response.data);
+					})
+					.catch(function(response) {
+						deferred.reject(response.data);
+					});
+				return deferred.promise;
+			},
+			update: function(name, data) {
+				var deferred = $q.defer();
+				$http.put('/api/admin/moduleSettings/' + name, data)
+          .then(function(response) {
+            deferred.resolve(response.data);
+          })
+          .catch(function(response) {
+            deferred.reject(response.data);
+          });
+        return deferred.promise;
+			},
+			save: function(name, data) {
+				var deferred = $q.defer();
+				$http.post('/api/admin/moduleSettings/' + name, data)
+          .then(function(response) {
+            deferred.resolve(response.data);
+          })
+          .catch(function(response) {
+            deferred.reject(response.data);
+          });
+        return deferred.promise;
+			}
+		};
+	}
+]);

--- a/public/services/modules.js
+++ b/public/services/modules.js
@@ -6,9 +6,9 @@
       return {
         get: function (callback) {
           $http.get('/api/admin/modules')
-            .success(function (data) {
-              callback(data);
-            });
+                    .then(function(response) {
+                        callback(response.data);
+                    });
         }
       };
     }

--- a/public/services/settings.js
+++ b/public/services/settings.js
@@ -5,23 +5,25 @@
     function ($http) {
       var get = function (callback) {
         // Temporary - probably it should to be resource based.
-        $http.get('/api/admin/settings').success(function (data, status, headers, config) {
+        $http.get('/api/admin/settings').then(function(response) {
+          var data = response.data;
           callback({
             success: true,
             settings: data
           });
-        }).error(function (data, status, headers, config) {
-          callback({
-            success: false
-          });
+        }).catch(function(response) {
+              callback({
+                  success: false
+              });
         });
       };
       var update = function (settings, callback) {
-        $http.put('/api/admin/settings', settings).success(function (data, status, headers, config) {
-          callback(data);
-        }).error(function (data, status, headers, config) {
-          callback(data);
-        });
+        $http.put('/api/admin/settings', settings).then(function(response) {
+              callback(response.data);
+            }).
+            catch(function(response) {
+                callback(response.data);
+            });
       };
       return {
         get: get,


### PR DESCRIPTION
`$http(...).success` and `$http(...).error` have been removed.
`$http(...).then` and `$http(...).catch` used instead as suggested at :
https://docs.angularjs.org/guide/migration#migrate1.5to1.6-ng-services-$http